### PR TITLE
fix `pixi.js-legacy` duplication

### DIFF
--- a/out/Grid.js
+++ b/out/Grid.js
@@ -1,16 +1,9 @@
-"use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.GridComponent = exports.Grid = void 0;
-const pixi_js_legacy_1 = require("pixi.js-legacy");
-const Partitioner_1 = __importDefault(require("./Partitioner"));
-function Grid(...objects) {
+import { Rectangle } from "pixi.js-legacy";
+import Partitioner from "./Partitioner";
+export function Grid(...objects) {
     return new GridComponent(...objects);
 }
-exports.Grid = Grid;
-class GridComponent extends Partitioner_1.default {
+export class GridComponent extends Partitioner {
     constructor(...children) {
         super(...children);
     }
@@ -24,7 +17,7 @@ class GridComponent extends Partitioner_1.default {
         let row = 0;
         let column = 0;
         for (let _ of containers) {
-            let partition = new pixi_js_legacy_1.Rectangle(space.x + column * width, space.y + row * height, width, height);
+            let partition = new Rectangle(space.x + column * width, space.y + row * height, width, height);
             yield partition;
             column++;
             if (column >= columns) {
@@ -34,4 +27,3 @@ class GridComponent extends Partitioner_1.default {
         }
     }
 }
-exports.GridComponent = GridComponent;

--- a/out/Leaf.js
+++ b/out/Leaf.js
@@ -1,8 +1,5 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.LeafComponent = exports.Leaf = void 0;
-const pixi_js_legacy_1 = require("pixi.js-legacy");
-const utils_1 = require("./utils");
+import { Rectangle, Container } from "pixi.js-legacy";
+import { getDimension } from "./utils";
 var Resize;
 (function (Resize) {
     Resize[Resize["None"] = 0] = "None";
@@ -16,14 +13,13 @@ var Align;
     Align[Align["End"] = 2] = "End";
     Align[Align["None"] = 3] = "None";
 })(Align || (Align = {}));
-function Leaf(child) {
+export function Leaf(child) {
     return new LeafComponent(child);
 }
-exports.Leaf = Leaf;
-class LeafComponent extends pixi_js_legacy_1.Container {
+export class LeafComponent extends Container {
     constructor(child) {
         super();
-        this._space = new pixi_js_legacy_1.Rectangle();
+        this._space = new Rectangle();
         this._maxWidth = Infinity;
         this._maxHeight = Infinity;
         this._minWidth = 0;
@@ -94,15 +90,15 @@ class LeafComponent extends pixi_js_legacy_1.Container {
             return;
         }
         this._space = space.clone();
-        let padding = (0, utils_1.getDimension)(this._padding, Math.max(space.width, space.height));
+        let padding = getDimension(this._padding, Math.max(space.width, space.height));
         space.x += padding;
         space.y += padding;
         space.width -= padding * 2;
         space.height -= padding * 2;
-        let maxWidth = (0, utils_1.getDimension)(this._maxWidth, space.width);
-        let maxHeight = (0, utils_1.getDimension)(this._maxHeight, space.height);
-        let minWidth = (0, utils_1.getDimension)(this._minWidth, space.width);
-        let minHeight = (0, utils_1.getDimension)(this._minHeight, space.height);
+        let maxWidth = getDimension(this._maxWidth, space.width);
+        let maxHeight = getDimension(this._maxHeight, space.height);
+        let minWidth = getDimension(this._minWidth, space.width);
+        let minHeight = getDimension(this._minHeight, space.height);
         let x = this._child.x;
         let y = this._child.y;
         let width = this._child.width;
@@ -177,4 +173,3 @@ class LeafComponent extends pixi_js_legacy_1.Container {
         }
     }
 }
-exports.LeafComponent = LeafComponent;

--- a/out/Partitioner.js
+++ b/out/Partitioner.js
@@ -1,8 +1,6 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-const pixi_js_legacy_1 = require("pixi.js-legacy");
-const Leaf_1 = require("./Leaf");
-class Partitioner extends pixi_js_legacy_1.Container {
+import { Container, Graphics, Rectangle } from "pixi.js-legacy";
+import { Leaf, LeafComponent } from "./Leaf";
+export default class Partitioner extends Container {
     constructor(...children) {
         super();
         this._debug = false;
@@ -28,11 +26,11 @@ class Partitioner extends pixi_js_legacy_1.Container {
             if (child instanceof Partitioner) {
                 child.leaves(fn);
             }
-            else if (child instanceof Leaf_1.LeafComponent) {
+            else if (child instanceof LeafComponent) {
                 this._group[i] = fn(child);
             }
             else if (this._isContainer(child)) {
-                this._group[i] = fn((0, Leaf_1.Leaf)(child));
+                this._group[i] = fn(Leaf(child));
             }
             i += 1;
         }
@@ -101,14 +99,14 @@ class Partitioner extends pixi_js_legacy_1.Container {
                 throw new Error("more partitions than children");
             }
             i += 1;
-            let container = new pixi_js_legacy_1.Container();
+            let container = new Container();
             container.x = partition.x;
             container.y = partition.y;
             container.width = partition.width;
             container.height = partition.height;
             container.zIndex = child.zIndex;
             if (this._debug) {
-                let dbg = new pixi_js_legacy_1.Graphics();
+                let dbg = new Graphics();
                 dbg.name = "dbg";
                 dbg.zIndex = -Infinity;
                 dbg.beginFill(0x000000, 0.05);
@@ -122,7 +120,7 @@ class Partitioner extends pixi_js_legacy_1.Container {
                 child._debug = this._debug;
             }
             if ("arrange" in child && typeof child.arrange === "function") {
-                child.arrange(new pixi_js_legacy_1.Rectangle(0, 0, partition.width, partition.height));
+                child.arrange(new Rectangle(0, 0, partition.width, partition.height));
             }
         }
         if (i < this._group.length) {
@@ -130,4 +128,3 @@ class Partitioner extends pixi_js_legacy_1.Container {
         }
     }
 }
-exports.default = Partitioner;

--- a/out/Positioner.js
+++ b/out/Positioner.js
@@ -1,2 +1,1 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
+export {};

--- a/out/Stack.js
+++ b/out/Stack.js
@@ -1,30 +1,21 @@
-"use strict";
-var __importDefault = (this && this.__importDefault) || function (mod) {
-    return (mod && mod.__esModule) ? mod : { "default": mod };
-};
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.StackComponent = exports.VStack = exports.HStack = exports.Stack = void 0;
-const pixi_js_legacy_1 = require("pixi.js-legacy");
-const Partitioner_1 = __importDefault(require("./Partitioner"));
+import { Rectangle } from "pixi.js-legacy";
+import Partitioner from "./Partitioner";
 var Direction;
 (function (Direction) {
     Direction[Direction["Horizontal"] = 0] = "Horizontal";
     Direction[Direction["Vertical"] = 1] = "Vertical";
     Direction[Direction["Auto"] = 2] = "Auto";
 })(Direction || (Direction = {}));
-function Stack(...objects) {
+export function Stack(...objects) {
     return new StackComponent(...objects);
 }
-exports.Stack = Stack;
-function HStack(...objects) {
+export function HStack(...objects) {
     return new StackComponent(...objects).horizontal();
 }
-exports.HStack = HStack;
-function VStack(...objects) {
+export function VStack(...objects) {
     return new StackComponent(...objects).vertical();
 }
-exports.VStack = VStack;
-class StackComponent extends Partitioner_1.default {
+export class StackComponent extends Partitioner {
     constructor(...children) {
         super(...children);
         this._spacing = 0;
@@ -58,7 +49,7 @@ class StackComponent extends Partitioner_1.default {
         for (let _ of objects) {
             let proportion = this._proportions[i++];
             let splitWidth = width * proportion;
-            let partition = new pixi_js_legacy_1.Rectangle(x, space.y, splitWidth, space.height);
+            let partition = new Rectangle(x, space.y, splitWidth, space.height);
             x += splitWidth + this._spacing;
             yield partition;
         }
@@ -70,7 +61,7 @@ class StackComponent extends Partitioner_1.default {
         for (let _ of objects) {
             let proportion = this._proportions[i++];
             let splitHeight = height * proportion;
-            let partition = new pixi_js_legacy_1.Rectangle(space.x, y, space.width, splitHeight);
+            let partition = new Rectangle(space.x, y, space.width, splitHeight);
             y += splitHeight + this._spacing;
             yield partition;
         }
@@ -89,4 +80,3 @@ class StackComponent extends Partitioner_1.default {
         }
     }
 }
-exports.StackComponent = StackComponent;

--- a/out/index.js
+++ b/out/index.js
@@ -1,11 +1,4 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.Grid = exports.Leaf = exports.VStack = exports.HStack = exports.Stack = void 0;
-const Stack_1 = require("./Stack");
-Object.defineProperty(exports, "HStack", { enumerable: true, get: function () { return Stack_1.HStack; } });
-Object.defineProperty(exports, "VStack", { enumerable: true, get: function () { return Stack_1.VStack; } });
-Object.defineProperty(exports, "Stack", { enumerable: true, get: function () { return Stack_1.Stack; } });
-const Leaf_1 = require("./Leaf");
-Object.defineProperty(exports, "Leaf", { enumerable: true, get: function () { return Leaf_1.Leaf; } });
-const Grid_1 = require("./Grid");
-Object.defineProperty(exports, "Grid", { enumerable: true, get: function () { return Grid_1.Grid; } });
+import { HStack, VStack, Stack } from "./Stack";
+import { Leaf } from "./Leaf";
+import { Grid } from "./Grid";
+export { Stack, HStack, VStack, Leaf, Grid };

--- a/out/utils.js
+++ b/out/utils.js
@@ -1,7 +1,4 @@
-"use strict";
-Object.defineProperty(exports, "__esModule", { value: true });
-exports.getDimension = void 0;
-function getDimension(value, reference) {
+export function getDimension(value, reference) {
     if (typeof value === "number") {
         return value;
     }
@@ -10,4 +7,3 @@ function getDimension(value, reference) {
     }
     throw new Error(`Invalid value: ${value}`);
 }
-exports.getDimension = getDimension;

--- a/package-lock.json
+++ b/package-lock.json
@@ -1,16 +1,13 @@
 {
   "name": "pixijs-layout",
-  "version": "0.1.7",
+  "version": "0.1.11",
   "lockfileVersion": 3,
   "requires": true,
   "packages": {
     "": {
       "name": "pixijs-layout",
-      "version": "0.1.7",
+      "version": "0.1.11",
       "license": "MIT",
-      "dependencies": {
-        "pixi.js-legacy": "^7.3.2"
-      },
       "devDependencies": {
         "@mapbox/node-pre-gyp": "^1.0.11",
         "@types/jest": "^29.5.3",
@@ -21,6 +18,9 @@
         "ts-jest": "^29.1.1",
         "ts-node": "^10.9.1",
         "typescript": "^5.1.6"
+      },
+      "peerDependencies": {
+        "pixi.js-legacy": "^7.3.2"
       }
     },
     "node_modules/@ampproject/remapping": {
@@ -1055,6 +1055,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/accessibility/-/accessibility-7.3.2.tgz",
       "integrity": "sha512-MdkU22HTauRvq9cMeWZIQGaDDa86sr+m12rKNdLV+FaDQgP/AhP+qCVpK7IKeJa9BrWGXaYMw/vueij7HkyDSA==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2",
         "@pixi/display": "7.3.2",
@@ -1065,6 +1066,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/app/-/app-7.3.2.tgz",
       "integrity": "sha512-3YRFSMvAxDebAz3/JJv+2jzbPkT8cHC0IHmmLRN8krDL1pZV+YjMLgMwN/Oeyv5TSbwNqnrF5su5whNkRaxeZQ==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2",
         "@pixi/display": "7.3.2"
@@ -1074,6 +1076,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/assets/-/assets-7.3.2.tgz",
       "integrity": "sha512-yteq6ptAxA09EcwU9D9hl7qr5yWIqy+c2PsXkTDkc76vTAwIamLY3KxLq2aR5y1U4L4O6aHFJd26uNhHcuTPmw==",
+      "peer": true,
       "dependencies": {
         "@types/css-font-loading-module": "^0.0.7"
       },
@@ -1086,6 +1089,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/canvas-display/-/canvas-display-7.3.2.tgz",
       "integrity": "sha512-VqeZ/6kwhzwaDWbdFD532HD9eDYu7h7ny8JfFDxGpdgzfhTVed/4mpYfSD6OmLxGcnnNhAUEc2QfS+hgamTKZg==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/display": "7.3.2"
       }
@@ -1094,6 +1098,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/canvas-extract/-/canvas-extract-7.3.2.tgz",
       "integrity": "sha512-d96oQQlNNfeEV4cmN3MJV4vcn0xBVN8WVvTahQTtGqX+0FphLoe5G/4y/l5V3tyOy5OaRZ4l2mXw6RS9wfBcFA==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/canvas-renderer": "7.3.2",
         "@pixi/core": "7.3.2",
@@ -1105,6 +1110,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/canvas-graphics/-/canvas-graphics-7.3.2.tgz",
       "integrity": "sha512-r/nPcriocJXqbiieWHpXWGL+5KcQPZGFDkJR28bGDKX6XBv0h7hhY1zX15bKa9zhbGK+MXrahSMYr6I+bLCAow==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/canvas-display": "7.3.2",
         "@pixi/canvas-renderer": "7.3.2",
@@ -1116,6 +1122,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/canvas-mesh/-/canvas-mesh-7.3.2.tgz",
       "integrity": "sha512-z97rrQS/rZ0bC+laB5Id7LCFl9WBU7UPb6tJflFL6iIBQrtAFmfvfjLfXWEXJk/1AcbN6W61AD6I2EEbBEG2Rw==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/canvas-display": "7.3.2",
         "@pixi/canvas-renderer": "7.3.2",
@@ -1128,6 +1135,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/canvas-particle-container/-/canvas-particle-container-7.3.2.tgz",
       "integrity": "sha512-qk7gw8ILrRvl8N6+CkGzrsNp1fBOUmPRxJlb3tfAn9dNOITwKCszysZHoMFNZy1rIpbe6oPgHNZ3/okSSHsw1A==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/particle-container": "7.3.2"
       }
@@ -1136,6 +1144,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/canvas-prepare/-/canvas-prepare-7.3.2.tgz",
       "integrity": "sha512-btUzzPv1/tKI/QIzbdA8wMk0W7QXdb5dYntX64UIqh1lU2QAzHlOJmCQ1QzJGKKiuSnxZLPCXo7UGogNENf/5A==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/canvas-renderer": "7.3.2",
         "@pixi/core": "7.3.2",
@@ -1146,6 +1155,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/canvas-renderer/-/canvas-renderer-7.3.2.tgz",
       "integrity": "sha512-LnZefvP8OhAagHQP3NvE03JYiJJkLucHd9Wdx7n7rcR8l2GYWqEPPtxgC7z+ZmWWFXTGXZJwGGRVj/RUPJWKdQ==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2"
       }
@@ -1154,6 +1164,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/canvas-sprite/-/canvas-sprite-7.3.2.tgz",
       "integrity": "sha512-MwBt9zJHMQONK//cApnMIGl5PO+iHDh8BfqoETUocEPKWLTS0CWeP0Sj05n+014wpqIQfpmpzkBLGiw3C1m2Dw==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/canvas-display": "7.3.2",
         "@pixi/canvas-renderer": "7.3.2",
@@ -1165,6 +1176,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/canvas-sprite-tiling/-/canvas-sprite-tiling-7.3.2.tgz",
       "integrity": "sha512-8d1uugMYBkTQ4tfGu4bcuM2E6o7RQmPdX2BwyD1gYcS1lUHx888tV2Fe8hBL4yiEcIY7dzsfoGWvvhRSKTh5oQ==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/canvas-renderer": "7.3.2",
         "@pixi/canvas-sprite": "7.3.2",
@@ -1176,6 +1188,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/canvas-text/-/canvas-text-7.3.2.tgz",
       "integrity": "sha512-DI4nu2efdjZq9XciewwkdiMzp7jPhFy/Dhz233nXT5B3KeR/2IOetUIHvam9n12aPmrLhhdVR+NYD8omIm8UXg==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/canvas-sprite": "7.3.2",
         "@pixi/sprite": "7.3.2",
@@ -1186,6 +1199,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/color/-/color-7.3.2.tgz",
       "integrity": "sha512-jur5PvdOtUBEUTjmPudW5qdQq6yYGlVGsi3HyhasJw14bN+GKJwiCKgIsyrsiNL5HBUXmje4ICwQohf6BqKqxA==",
+      "peer": true,
       "dependencies": {
         "@pixi/colord": "^2.9.6"
       }
@@ -1193,12 +1207,14 @@
     "node_modules/@pixi/colord": {
       "version": "2.9.6",
       "resolved": "https://registry.npmjs.org/@pixi/colord/-/colord-2.9.6.tgz",
-      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA=="
+      "integrity": "sha512-nezytU2pw587fQstUu1AsJZDVEynjskwOL+kibwcdxsMBFqPsFFNA7xl0ii/gXuDi6M0xj3mfRJj8pBSc2jCfA==",
+      "peer": true
     },
     "node_modules/@pixi/compressed-textures": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/compressed-textures/-/compressed-textures-7.3.2.tgz",
       "integrity": "sha512-J3ENMHDPQO6CJRei55gqI0WmiZJIK6SgsW5AEkShT0aAe5miEBSomv70pXw/58ru+4/Hx8cXjamsGt4aQB2D0Q==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/assets": "7.3.2",
         "@pixi/core": "7.3.2"
@@ -1207,12 +1223,14 @@
     "node_modules/@pixi/constants": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/constants/-/constants-7.3.2.tgz",
-      "integrity": "sha512-Q8W3ncsFxmfgC5EtokpG92qJZabd+Dl+pbQAdHwiPY3v+8UNq77u4VN2qtl1Z04864hCcg7AStIYEDrzqTLF6Q=="
+      "integrity": "sha512-Q8W3ncsFxmfgC5EtokpG92qJZabd+Dl+pbQAdHwiPY3v+8UNq77u4VN2qtl1Z04864hCcg7AStIYEDrzqTLF6Q==",
+      "peer": true
     },
     "node_modules/@pixi/core": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/core/-/core-7.3.2.tgz",
       "integrity": "sha512-Pta3ee8MtJ3yKxGXzglBWgwbEOKMB6Eth+FpLTjL0rgxiqTB550YX6jsNEQQAzcGjCBlO3rC/IF57UZ2go/X6w==",
+      "peer": true,
       "dependencies": {
         "@pixi/color": "7.3.2",
         "@pixi/constants": "7.3.2",
@@ -1233,6 +1251,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/display/-/display-7.3.2.tgz",
       "integrity": "sha512-cY5AnZ3TWt5GYGx4e5AQ2/2U9kP+RorBg/O30amJ+8e9bFk9rS8cjh/DDq/hc4lql96BkXAInTl40eHnAML5lQ==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2"
       }
@@ -1241,6 +1260,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/events/-/events-7.3.2.tgz",
       "integrity": "sha512-Moca9epu8jk1wIQCdVYjhz2pD9Ol21m50wvWUKvpgt9yM/AjkCLSDt8HO/PmTpavDrkhx5pVVWeDDA6FyUNaGA==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2",
         "@pixi/display": "7.3.2"
@@ -1249,12 +1269,14 @@
     "node_modules/@pixi/extensions": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/extensions/-/extensions-7.3.2.tgz",
-      "integrity": "sha512-Qw84ADfvmVu4Mwj+zTik/IEEK9lWS5n4trbrpQCcEZ+Mb8oRAXWvKz199mi1s7+LaZXDqeCY1yr2PHQaFf1KBA=="
+      "integrity": "sha512-Qw84ADfvmVu4Mwj+zTik/IEEK9lWS5n4trbrpQCcEZ+Mb8oRAXWvKz199mi1s7+LaZXDqeCY1yr2PHQaFf1KBA==",
+      "peer": true
     },
     "node_modules/@pixi/extract": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/extract/-/extract-7.3.2.tgz",
       "integrity": "sha512-KsoflvQZV/XD8A8xbtRnmI4reYekbI4MOi7ilwQe5tMz6O1mO7IzrSukxkSMD02f6SpbAqbi7a1EayTjvY0ECQ==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2"
       }
@@ -1263,6 +1285,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/filter-alpha/-/filter-alpha-7.3.2.tgz",
       "integrity": "sha512-nZMdn310wH5ZK1slwv3X4qT8eLoAGO7SgYGCy5IsMtpCtNObzE9XA4tAfhXrjihyzPS9KvszgAbnv1Qpfh0/uw==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2"
       }
@@ -1271,6 +1294,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/filter-blur/-/filter-blur-7.3.2.tgz",
       "integrity": "sha512-unu3zhwHMhN+iAe7Td2rK40i2UJ2GOhzWK+6jcU3ZkMOsFCT5kgBoMRTejeQVcvCs6GoYK8imbkE7mXt05Vj6A==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2"
       }
@@ -1279,6 +1303,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/filter-color-matrix/-/filter-color-matrix-7.3.2.tgz",
       "integrity": "sha512-rbyjes/9SMoV9jjPiK0sLMkmLfN8D17GoTJIfq/KLv1x9646W5fL2QSKkN04UkZ+020ndWvIOxK1S97tvRyCfg==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2"
       }
@@ -1287,6 +1312,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/filter-displacement/-/filter-displacement-7.3.2.tgz",
       "integrity": "sha512-ZHl7Sfb8JYd9Z6j96OHCC0NhMKhhXJRE5AbkSDohjEMVCK1BV5rDGAHV8WVt/2MJ/j83CXUpydzyMhdM4lMchg==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2"
       }
@@ -1295,6 +1321,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/filter-fxaa/-/filter-fxaa-7.3.2.tgz",
       "integrity": "sha512-9brtlxDnQTZk2XiFBKdBK9e+8CX9LdxxcL7LRpjEyiHuAPvTlQgu9B85LrJ4GzWKqJJKaIIZBzhIoiCLUnfeXg==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2"
       }
@@ -1303,6 +1330,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/filter-noise/-/filter-noise-7.3.2.tgz",
       "integrity": "sha512-F8GQQ20n7tCjThX6GCXckiXz2YffOCxicTJ0oat9aVDZh+sVsAxYX0aKSdHh0hhv18F0yuc6tPsSL5DYb63xFg==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2"
       }
@@ -1311,6 +1339,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/graphics/-/graphics-7.3.2.tgz",
       "integrity": "sha512-PhU6j1yub4tH/s+/gqByzgZ3mLv1mfb6iGXbquycg3+WypcxHZn0opFtI/axsazaQ9SEaWxw1m3i40WG5ANH5g==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2",
         "@pixi/display": "7.3.2",
@@ -1320,12 +1349,14 @@
     "node_modules/@pixi/math": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/math/-/math-7.3.2.tgz",
-      "integrity": "sha512-dutoZ0IVJ5ME7UtYNo2szu4D7qsgtJB7e3ylujBVu7BOP2e710BVtFwFSFV768N14h9H5roGnuzVoDiJac2u+w=="
+      "integrity": "sha512-dutoZ0IVJ5ME7UtYNo2szu4D7qsgtJB7e3ylujBVu7BOP2e710BVtFwFSFV768N14h9H5roGnuzVoDiJac2u+w==",
+      "peer": true
     },
     "node_modules/@pixi/mesh": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/mesh/-/mesh-7.3.2.tgz",
       "integrity": "sha512-LFkt7ELYXQLgbgHpjl68j6JD5ejUwma8zoPn2gqSBbY+6pK/phjvV1Wkh76muF46VvNulgXF0+qLIDdCsfrDaA==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2",
         "@pixi/display": "7.3.2"
@@ -1335,6 +1366,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/mesh-extras/-/mesh-extras-7.3.2.tgz",
       "integrity": "sha512-s/tg9TsTZZxLEdCDKWnBChDGkc041HCTP7ykJv4fEROzb9B0lskULYyvv+/YNNKa2Ugb9WnkMknpOdOXCpjyyg==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2",
         "@pixi/mesh": "7.3.2"
@@ -1344,6 +1376,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/mixin-cache-as-bitmap/-/mixin-cache-as-bitmap-7.3.2.tgz",
       "integrity": "sha512-bZRlyUN5+9kCUjn67V0IFtYIrbmx9Vs4sMOmXyrX3Q4B4gPLE46IzZz3v0IVaTjp32udlQztfJalIaWbuqgb3A==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2",
         "@pixi/display": "7.3.2",
@@ -1354,6 +1387,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/mixin-get-child-by-name/-/mixin-get-child-by-name-7.3.2.tgz",
       "integrity": "sha512-mbUi3WxXrkViH7qOgjk4fu2BN36NwNb7u+Fy1J5dS8Bntj57ZVKmEV9PbUy0zYjXE8rVmeAvSu/2kbn5n9UutQ==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/display": "7.3.2"
       }
@@ -1362,6 +1396,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/mixin-get-global-position/-/mixin-get-global-position-7.3.2.tgz",
       "integrity": "sha512-1nhWbBgmw6rK7yQJxzeI9yjKYYEkM5i3pee8qVu4YWo3b1xWVQA7osQG7aGM/4qywDkXaA1ZvciA5hfg6f4Q5Q==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2",
         "@pixi/display": "7.3.2"
@@ -1371,6 +1406,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/particle-container/-/particle-container-7.3.2.tgz",
       "integrity": "sha512-JYc4j4z97KmxyLp+1Lg0SNi8hy6RxcBBNQGk+CSLNXeDWxx3hykT5gj/ORX1eXyzHh1ZCG1XzeVS9Yr8QhlFHA==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2",
         "@pixi/display": "7.3.2",
@@ -1381,6 +1417,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/prepare/-/prepare-7.3.2.tgz",
       "integrity": "sha512-aLPAXSYLUhMwxzJtn9m0TSZe+dQlZCt09QNBqYbSi8LZId54QMDyvfBb4zBOJZrD2xAZgYL5RIJuKHwZtFX6lQ==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2",
         "@pixi/display": "7.3.2",
@@ -1391,12 +1428,14 @@
     "node_modules/@pixi/runner": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/runner/-/runner-7.3.2.tgz",
-      "integrity": "sha512-maKotoKJCQiQGBJwfM+iYdQKjrPN/Tn9+72F4WIf706zp/5vKoxW688Rsktg5BX4Mcn7ZkZvcJYTxj2Mv87lFA=="
+      "integrity": "sha512-maKotoKJCQiQGBJwfM+iYdQKjrPN/Tn9+72F4WIf706zp/5vKoxW688Rsktg5BX4Mcn7ZkZvcJYTxj2Mv87lFA==",
+      "peer": true
     },
     "node_modules/@pixi/settings": {
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/settings/-/settings-7.3.2.tgz",
       "integrity": "sha512-vtxzuARDTbFe0fRYSqB53B+mPpX7v+QjjnCUmVMVvZiWr3QcngMWVml6c6dQDln7IakWoKZRrNG4FpggvDgLVg==",
+      "peer": true,
       "dependencies": {
         "@pixi/constants": "7.3.2",
         "@types/css-font-loading-module": "^0.0.7",
@@ -1407,6 +1446,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/sprite/-/sprite-7.3.2.tgz",
       "integrity": "sha512-IpWTKXExJNXVcY7ITopJ+JW48DahdbCo/81D2IYzBImq3jyiJM2Km5EoJgvAM5ZQ3Ev3KPPIBzYLD+HoPWcxdw==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2",
         "@pixi/display": "7.3.2"
@@ -1416,6 +1456,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/sprite-animated/-/sprite-animated-7.3.2.tgz",
       "integrity": "sha512-j9pyUe4cefxE9wecNfbWQyL5fBQKvCGYaOA0DE1X46ukBHrIuhA8u3jg2X3N3r4IcbVvxpWFYDrDsWXWeiBmSw==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2",
         "@pixi/sprite": "7.3.2"
@@ -1425,6 +1466,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/sprite-tiling/-/sprite-tiling-7.3.2.tgz",
       "integrity": "sha512-tWVVb/rMIx5AczfUrVxa0dZaIufP5C0IOL7IGfFUDQqDu5JSAUC0mwLe4F12jAXBVsqYhCGYx5bIHbPiI5vcSQ==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2",
         "@pixi/display": "7.3.2",
@@ -1435,6 +1477,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/spritesheet/-/spritesheet-7.3.2.tgz",
       "integrity": "sha512-UkwqrPYDqrEdK5ub9qn/9VBvt5caA8ffV5iYR6ssCvrpaQovBKmS+b5pr/BYf8xNTExDpR3OmPIo8iDEYWWLuw==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/assets": "7.3.2",
         "@pixi/core": "7.3.2"
@@ -1444,6 +1487,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/text/-/text-7.3.2.tgz",
       "integrity": "sha512-LdtNj+K5tPB/0UcDcO52M/C7xhwFTGFhtdF42fPhRuJawM23M3zm1Y8PapXv+mury+IxCHT1w30YlAi0qTVpKQ==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2",
         "@pixi/sprite": "7.3.2"
@@ -1453,6 +1497,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/text-bitmap/-/text-bitmap-7.3.2.tgz",
       "integrity": "sha512-p8KLgtZSPowWU/Zj+GVtfsUT8uGYo4TtKKYbLoWuxkRA5Pc1+4C9/rV/EOSFfoZIdW5C+iFg5VxRgBllUQf+aA==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/assets": "7.3.2",
         "@pixi/core": "7.3.2",
@@ -1465,6 +1510,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/text-html/-/text-html-7.3.2.tgz",
       "integrity": "sha512-IYhBWEPOvqUtlHkS5/c1Hseuricj5jrrGd21ivcvHmcnK/x2m+CRGvvzeBp1mqoYBnDbQVrD2wSXSe4Dv9tEJA==",
+      "peer": true,
       "peerDependencies": {
         "@pixi/core": "7.3.2",
         "@pixi/display": "7.3.2",
@@ -1476,6 +1522,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/ticker/-/ticker-7.3.2.tgz",
       "integrity": "sha512-5kIPhBeXwDJohCzKzJJ6T7f1oAGbHAgeiwOjlTO+9lNXUX8ZPj0407V3syuF+64kFqJzIBCznBRpI+fmT4c9SA==",
+      "peer": true,
       "dependencies": {
         "@pixi/extensions": "7.3.2",
         "@pixi/settings": "7.3.2",
@@ -1486,6 +1533,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/@pixi/utils/-/utils-7.3.2.tgz",
       "integrity": "sha512-KhNvj9YcY7Zi2dTKZgDpx8C6OxKKR541vwtG6JgdBZZYDeMBOIghN2Vi5zn4diW5BhDfHBmdSJ1wZXEtE2MDwg==",
+      "peer": true,
       "dependencies": {
         "@pixi/color": "7.3.2",
         "@pixi/constants": "7.3.2",
@@ -1597,12 +1645,14 @@
     "node_modules/@types/css-font-loading-module": {
       "version": "0.0.7",
       "resolved": "https://registry.npmjs.org/@types/css-font-loading-module/-/css-font-loading-module-0.0.7.tgz",
-      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q=="
+      "integrity": "sha512-nl09VhutdjINdWyXxHWN/w9zlNCfr60JUqJbd24YXUuCwgeL0TpFSdElCwb6cxfB6ybE19Gjj4g0jsgkXxKv1Q==",
+      "peer": true
     },
     "node_modules/@types/earcut": {
       "version": "2.1.3",
       "resolved": "https://registry.npmjs.org/@types/earcut/-/earcut-2.1.3.tgz",
-      "integrity": "sha512-pskpibEbm73+7nA9RqxGEnAiALRO92DdoSVxasyjGrqzEndaSDjFG73GCtstMzhdOowZMItVw2fhTdxVrY221w=="
+      "integrity": "sha512-pskpibEbm73+7nA9RqxGEnAiALRO92DdoSVxasyjGrqzEndaSDjFG73GCtstMzhdOowZMItVw2fhTdxVrY221w==",
+      "peer": true
     },
     "node_modules/@types/graceful-fs": {
       "version": "4.1.6",
@@ -1667,7 +1717,8 @@
     "node_modules/@types/offscreencanvas": {
       "version": "2019.7.2",
       "resolved": "https://registry.npmjs.org/@types/offscreencanvas/-/offscreencanvas-2019.7.2.tgz",
-      "integrity": "sha512-ujCjOxeA07IbEBQYAkoOI+XFw5sT3nhWJ/xZfPR6reJppDG7iPQPZacQiLTtWH1b3a2NYXWlxvYqa40y/LAixQ=="
+      "integrity": "sha512-ujCjOxeA07IbEBQYAkoOI+XFw5sT3nhWJ/xZfPR6reJppDG7iPQPZacQiLTtWH1b3a2NYXWlxvYqa40y/LAixQ==",
+      "peer": true
     },
     "node_modules/@types/stack-utils": {
       "version": "2.0.1",
@@ -2025,6 +2076,7 @@
       "version": "1.0.5",
       "resolved": "https://registry.npmjs.org/call-bind/-/call-bind-1.0.5.tgz",
       "integrity": "sha512-C3nQxfFZxFRVoJoGKKI8y3MOEo129NQ+FgQ08iye+Mk4zNZZGdjfs06bVTr+DBSlA66Q2VEcMki/cUCP4SercQ==",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2",
         "get-intrinsic": "^1.2.1",
@@ -2317,6 +2369,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/define-data-property/-/define-data-property-1.1.1.tgz",
       "integrity": "sha512-E7uGkTzkk1d0ByLeSc6ZsFS79Axg+m1P/VsgYsxHgiuc3tFSj+MjMIwe90FC4lOAZzNBdY7kkO2P2wKdsQ1vgQ==",
+      "peer": true,
       "dependencies": {
         "get-intrinsic": "^1.2.1",
         "gopd": "^1.0.1",
@@ -2392,7 +2445,8 @@
     "node_modules/earcut": {
       "version": "2.2.4",
       "resolved": "https://registry.npmjs.org/earcut/-/earcut-2.2.4.tgz",
-      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ=="
+      "integrity": "sha512-/pjZsA1b4RPHbeWZQn66SWS8nZZWLQQ23oE3Eam7aroEFGEvwKAsJfZ9ytiEMycfzXWpca4FA9QIOehf7PocBQ==",
+      "peer": true
     },
     "node_modules/electron-to-chromium": {
       "version": "1.4.477",
@@ -2512,7 +2566,8 @@
     "node_modules/eventemitter3": {
       "version": "4.0.7",
       "resolved": "https://registry.npmjs.org/eventemitter3/-/eventemitter3-4.0.7.tgz",
-      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw=="
+      "integrity": "sha512-8guHBZCwKnFhYdHr2ysuRWErTwhoN2X8XELRlrRwpmfeY2jjuUN4taQMsULKUVo1K4DvZl+0pgfyoysHxvmvEw==",
+      "peer": true
     },
     "node_modules/execa": {
       "version": "5.1.1",
@@ -2717,6 +2772,7 @@
       "version": "1.2.2",
       "resolved": "https://registry.npmjs.org/get-intrinsic/-/get-intrinsic-1.2.2.tgz",
       "integrity": "sha512-0gSo4ml/0j98Y3lngkFEot/zhiCeWsbYIlZ+uZOVgzLyLaUw7wxUL+nCTP0XJvJg1AXulJRI3UJi8GsbDuxdGA==",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2",
         "has-proto": "^1.0.1",
@@ -2781,6 +2837,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/gopd/-/gopd-1.0.1.tgz",
       "integrity": "sha512-d65bNlIadxvpb/A2abVdlqKqV563juRnZ1Wtk6s1sIR8uNsXR70xqIzVqxVf1eTqDunwT2MkczEeaezCKTZhwA==",
+      "peer": true,
       "dependencies": {
         "get-intrinsic": "^1.1.3"
       },
@@ -2819,6 +2876,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-property-descriptors/-/has-property-descriptors-1.0.1.tgz",
       "integrity": "sha512-VsX8eaIewvas0xnvinAe9bw4WfIeODpGYikiWYLH+dma0Jw6KHYqWiWfhQlgOVK8D6PvjubK5Uc4P0iIhIcNVg==",
+      "peer": true,
       "dependencies": {
         "get-intrinsic": "^1.2.2"
       },
@@ -2830,6 +2888,7 @@
       "version": "1.0.1",
       "resolved": "https://registry.npmjs.org/has-proto/-/has-proto-1.0.1.tgz",
       "integrity": "sha512-7qE+iP+O+bgF9clE5+UoBFzE65mlBiVj3tKCrlNQ0Ogwm0BjpT/gK4SlLYDMybDh5I3TCTKnPPa0oMG7JDYrhg==",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2841,6 +2900,7 @@
       "version": "1.0.3",
       "resolved": "https://registry.npmjs.org/has-symbols/-/has-symbols-1.0.3.tgz",
       "integrity": "sha512-l3LCuF6MgDNwTDKkdYGEihYjt5pRPbEg46rtlmnSPlUbgmB8LOIrKJbYYFBSbnPaJexMKtiPO8hmeRjRz2Td+A==",
+      "peer": true,
       "engines": {
         "node": ">= 0.4"
       },
@@ -2858,6 +2918,7 @@
       "version": "2.0.0",
       "resolved": "https://registry.npmjs.org/hasown/-/hasown-2.0.0.tgz",
       "integrity": "sha512-vUptKVTpIJhcczKBbgnS+RtcuYMB8+oNzPK2/Hp3hanz8JmpATdmmgLgSaadVREkDm+e2giHwY3ZRkyjSIDDFA==",
+      "peer": true,
       "dependencies": {
         "function-bind": "^1.1.2"
       },
@@ -3047,7 +3108,8 @@
     "node_modules/ismobilejs": {
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/ismobilejs/-/ismobilejs-1.1.1.tgz",
-      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw=="
+      "integrity": "sha512-VaFW53yt8QO61k2WJui0dHf4SlL8lxBofUuUmwBo0ljPk0Drz2TiuDW4jo3wDcv41qy/SxrJ+VAzJ/qYqsmzRw==",
+      "peer": true
     },
     "node_modules/istanbul-lib-coverage": {
       "version": "3.2.0",
@@ -4246,6 +4308,7 @@
       "version": "1.13.1",
       "resolved": "https://registry.npmjs.org/object-inspect/-/object-inspect-1.13.1.tgz",
       "integrity": "sha512-5qoj1RUiKOMsCCNLV1CBiPYE10sziTsnmNxkAI/rZhiD63CF7IqdFGC/XzjWjpSgLf0LxXX3bDFIh0E18f6UhQ==",
+      "peer": true,
       "funding": {
         "url": "https://github.com/sponsors/ljharb"
       }
@@ -4419,6 +4482,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/pixi.js/-/pixi.js-7.3.2.tgz",
       "integrity": "sha512-GJickUrT3UcBInGT1CU6cv2oktCdocE5QM74CD3t+weiJPPWIzleNlp7zrBR5QIDdU6bEO8CUgUXH2Y9QvlCMw==",
+      "peer": true,
       "dependencies": {
         "@pixi/accessibility": "7.3.2",
         "@pixi/app": "7.3.2",
@@ -4460,6 +4524,7 @@
       "version": "7.3.2",
       "resolved": "https://registry.npmjs.org/pixi.js-legacy/-/pixi.js-legacy-7.3.2.tgz",
       "integrity": "sha512-10nZf8jG0z7GJmg0cy53wWYzVDVCbMOMKTyhKm+NrWX8XmbIbsodYWAg1IdabnVbWKKg+zLX1dL+Wn6TakEeqw==",
+      "peer": true,
       "dependencies": {
         "@pixi/canvas-display": "7.3.2",
         "@pixi/canvas-extract": "7.3.2",
@@ -4553,7 +4618,8 @@
     "node_modules/punycode": {
       "version": "1.4.1",
       "resolved": "https://registry.npmjs.org/punycode/-/punycode-1.4.1.tgz",
-      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ=="
+      "integrity": "sha512-jmYNElW7yvO7TV33CjSmvSiE2yco3bV2czu/OzDKdMNVZQWfxCblURLhf+47syQRBntjfLdd/H0egrzIG+oaFQ==",
+      "peer": true
     },
     "node_modules/pure-rand": {
       "version": "6.0.2",
@@ -4575,6 +4641,7 @@
       "version": "6.11.2",
       "resolved": "https://registry.npmjs.org/qs/-/qs-6.11.2.tgz",
       "integrity": "sha512-tDNIz22aBzCDxLtVH++VnTfzxlfeK5CbqohpSqpJgj1Wg/cQbStNAz3NuqCs5vV+pjBsK4x4pN9HlVh7rcYRiA==",
+      "peer": true,
       "dependencies": {
         "side-channel": "^1.0.4"
       },
@@ -4745,6 +4812,7 @@
       "version": "1.1.1",
       "resolved": "https://registry.npmjs.org/set-function-length/-/set-function-length-1.1.1.tgz",
       "integrity": "sha512-VoaqjbBJKiWtg4yRcKBQ7g7wnGnLV3M8oLvVWwOk2PdYY6PEFegR1vezXR0tw6fZGF9csVakIRjrJiy2veSBFQ==",
+      "peer": true,
       "dependencies": {
         "define-data-property": "^1.1.1",
         "get-intrinsic": "^1.2.1",
@@ -4780,6 +4848,7 @@
       "version": "1.0.4",
       "resolved": "https://registry.npmjs.org/side-channel/-/side-channel-1.0.4.tgz",
       "integrity": "sha512-q5XPytqFEIKHkGdiMIrY10mvLRvnQh42/+GoBlFW3b2LXLE2xxJpZFdm94we0BaoV3RwJyGqg5wS7epxTv0Zvw==",
+      "peer": true,
       "dependencies": {
         "call-bind": "^1.0.0",
         "get-intrinsic": "^1.0.2",
@@ -5276,6 +5345,7 @@
       "version": "0.11.3",
       "resolved": "https://registry.npmjs.org/url/-/url-0.11.3.tgz",
       "integrity": "sha512-6hxOLGfZASQK/cijlZnZJTq8OXAkt/3YGfQX45vvMYXpZoo8NdWZcY73K108Jf759lS1Bv/8wXnHDTSz17dSRw==",
+      "peer": true,
       "dependencies": {
         "punycode": "^1.4.1",
         "qs": "^6.11.2"

--- a/tsconfig.json
+++ b/tsconfig.json
@@ -22,9 +22,9 @@
     // "useDefineForClassFields": true,                  /* Emit ECMAScript-standard-compliant class fields. */
     // "moduleDetection": "auto",                        /* Control what method is used to detect module-format JS files. */
     /* Modules */
-    "module": "commonjs", /* Specify what module code is generated. */
+    "module": "es2015", /* Specify what module code is generated. */
     // "rootDir": "./",                                  /* Specify the root folder within your source files. */
-    // "moduleResolution": "node10",                     /* Specify how TypeScript looks up a file from a given module specifier. */
+    "moduleResolution": "bundler",                     /* Specify how TypeScript looks up a file from a given module specifier. */
     // "baseUrl": "./",                                  /* Specify the base directory to resolve non-relative module names. */
     // "paths": {},                                      /* Specify a set of entries that re-map imports to additional lookup locations. */
     // "rootDirs": [],                                   /* Allow multiple folders to be treated as one when resolving modules. */


### PR DESCRIPTION
https://github.com/samwho/js-mjs-example

---

`package.json` defines this package as a ES Module, but `tsc` compiled it as a CommonJS one, leading to a duplication of `pixi.js-legacy` (one copy is a ESM dependency, another — is a CommonJS)

https://www.typescriptlang.org/docs/handbook/modules/reference.html#es2015-es2020-es2022-esnext